### PR TITLE
add arm64 version

### DIFF
--- a/.github/workflows/supabase-images.yml
+++ b/.github/workflows/supabase-images.yml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        platform: [linux/amd64, linux/arm64]
         image:
           # Core Supabase services (matching docker-compose.yml versions)
           - name: supabase/studio:2025.06.30-sha-6f5982d
@@ -61,14 +62,16 @@ jobs:
           - name: inbucket/inbucket:3.0.3
             short-name: mail
             scan: true
-            
-    name: Process ${{ matrix.image.short-name }}
+
+    name: Process ${{ matrix.image.short-name }} on ${{ matrix.platform }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          platforms: ${{ matrix.platform }}
 
       - name: Pull Docker Image
         if: matrix.image.scan == true


### PR DESCRIPTION
Working on signed commits still... this is a quick fix to get the github action to publish both container image formats to better support local dev

<img width="566" height="597" alt="Screenshot 2025-08-14 at 1 11 48 PM" src="https://github.com/user-attachments/assets/651aa526-feb4-4a0e-b487-67ec18632c01" />
